### PR TITLE
No need for catch2.

### DIFF
--- a/build-endless-sky
+++ b/build-endless-sky
@@ -29,8 +29,6 @@ packages=(
 	uuid-dev
 	libatomic-ops-dev
 	libminizip-dev
-
-	catch2			# required for linux-armv7 preset
 )
 sudo apt install -y "${packages[@]}"
 
@@ -40,4 +38,4 @@ sudo apt install -y "${packages[@]}"
 }
 
 cmake -DBUILD_TESTING=OFF --preset linux-armv7
-cmake --build --preset linux-armv7-release
+cmake --build --preset linux-armv7-release --target EndlessSky


### PR DESCRIPTION
@M68HC060

As the [build instructions](https://github.com/endless-sky/endless-sky/blob/7cc1fddf0c60b669bcac3ea12ae7e73f617485d9/docs/readme-developer.md) mention, it is possible to build the game without the tests, in which case catch2 is not needed.

Tested on my 3B+.